### PR TITLE
Support autoprefixing for older browsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,35 @@ postcss([
   });
 ```
 
+
+#### Options
+
+Options can be passed for individual processors:
+
+```js
+postcss([
+  require('postcss-travix')({
+    autoprefixer: {
+      browsers: ['last 2 versions']
+    }
+  })
+]);
+```
+
+You can also disable some plugins:
+
+```js
+postcss([
+  require('postcss-travix')({
+    autoprefixer: {
+      disabled: true
+    }
+  })
+]);
+```
+
+You can find the list of processors with their names and default options in [`processors.js`](./processors.js) file.
+
 ## Features
 
 ### Nesting
@@ -49,6 +78,35 @@ Output:
 ```css
 .nested .selector .here {
   padding: 0;
+}
+```
+
+### Autoprefixing
+
+We support compatibility with older versions of browsers, and the current list of browsers consists of:
+
+* `last 2 versions`
+* `Explorer >= 10`
+* `Safari >= 5`
+
+The naming convention of the browsers follow [Browserslist](https://github.com/ai/browserslist).
+
+Input:
+
+```css
+.myClass {
+  flex: 1;
+}
+```
+
+Output:
+
+```css
+.myClass {
+  -webkit-box-flex: 1;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
 }
 ```
 

--- a/index.js
+++ b/index.js
@@ -1,13 +1,6 @@
 const postcss = require('postcss');
-const postcssNestedPlugin = require('postcss-nested');
 
-const processors = [
-  {
-    plugin: postcssNestedPlugin,
-    namespace: 'nested',
-    defaults: {},
-  },
-];
+const processors = require('./processors');
 
 module.exports = postcss.plugin('travix', function (opts) {
   const options = opts || {};

--- a/package.json
+++ b/package.json
@@ -19,14 +19,15 @@
     "url": "https://github.com/Travix-International/postcss-travix/issues"
   },
   "homepage": "https://github.com/Travix-International/postcss-travix#readme",
+  "dependencies": {
+    "autoprefixer": "^7.1.1",
+    "postcss-nested": "^2.0.2"
+  },
   "devDependencies": {
     "chai": "^4.0.2",
     "eslint": "^4.0.0",
     "eslint-config-travix": "^2.3.2",
     "mocha": "^3.4.2",
     "postcss": "^6.0.2"
-  },
-  "dependencies": {
-    "postcss-nested": "^2.0.2"
   }
 }

--- a/processors.js
+++ b/processors.js
@@ -1,0 +1,21 @@
+const postcssNestedPlugin = require('postcss-nested');
+const postcssAutoprefixerPlugin = require('autoprefixer');
+
+module.exports = [
+  {
+    plugin: postcssNestedPlugin,
+    namespace: 'nested',
+    defaults: {},
+  },
+  {
+    plugin: postcssAutoprefixerPlugin,
+    namespace: 'autoprefixer',
+    defaults: {
+      browsers: [
+        'last 2 versions',
+        'Explorer >= 10',
+        'Safari >= 5',
+      ],
+    },
+  },
+];

--- a/test/fixtures/autoprefixer.css
+++ b/test/fixtures/autoprefixer.css
@@ -1,0 +1,3 @@
+.myClass {
+  flex: 1;
+}

--- a/test/fixtures/autoprefixer.expected.css
+++ b/test/fixtures/autoprefixer.expected.css
@@ -1,0 +1,6 @@
+.myClass {
+  -webkit-box-flex: 1;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+}


### PR DESCRIPTION
Closes #1 

## What's done

* Added `autoprefixer` as a processor
* Docs for `options`

## Note to developers

If we can establish a rule for using PostCSS with `postcss-travix` for processing CSS everywhere, then we can manage the list of older versions of browsers that we need to support in just one place. Here.